### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 # Reference: <https://help.github.com/en/actions/language-and-framework-guides/using-nodejs-with-github-actions>
 name: Build
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/final-hill/cathedral/security/code-scanning/1](https://github.com/final-hill/cathedral/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow primarily involves reading repository contents (e.g., checking out code and installing dependencies), the `contents: read` permission is sufficient. This limits the `GITHUB_TOKEN` to read-only access, ensuring that the workflow cannot inadvertently modify repository contents.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added to individual jobs if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
