### PR TITLE
Refactor Slack user linking logic

### DIFF
--- a/application/PermissionInteractor.ts
+++ b/application/PermissionInteractor.ts
@@ -38,15 +38,6 @@ export class PermissionInteractor {
     }
 
     /**
-     * Check if the user is the Slack bot
-     * @throws {PermissionDeniedException} If the user is not the Slack bot and not a system admin
-     */
-    assertSlackBot(): void {
-        if (!this.isSlackBot() && !this.isSystemAdmin())
-            throw new PermissionDeniedException('Forbidden: You do not have permissions to perform this action.')
-    }
-
-    /**
      * Check if the user is an organization admin
      * @param organizationId Optional organization ID for organization-specific checks
      * @throws {PermissionDeniedException} If the user is not an organization admin
@@ -200,10 +191,6 @@ export class PermissionInteractor {
      */
     isSystemAdmin(): boolean {
         return this._session.user!.isSystemAdmin
-    }
-
-    isSlackBot(): boolean {
-        return this._session.user!.id === useRuntimeConfig().systemSlackUserId
     }
 
     /**

--- a/application/slack/SlackEventInteractor.ts
+++ b/application/slack/SlackEventInteractor.ts
@@ -197,7 +197,7 @@ export class SlackEventInteractor extends Interactor<z.infer<typeof slackBodySch
         this.assertUserIdentity(cathedralUserId)
 
         // Link the Slack user to the Cathedral user
-        await this._userInteractor.linkSlackUserAsUser({
+        await this._userInteractor.linkUser({
             slackUserId: payload.user.id,
             teamId: payload.team?.id || '',
             cathedralUserId: cathedralUserId,

--- a/application/slack/SlackEventInteractor.ts
+++ b/application/slack/SlackEventInteractor.ts
@@ -203,7 +203,7 @@ export class SlackEventInteractor extends Interactor<z.infer<typeof slackBodySch
             cathedralUserId: cathedralUserId,
             creationDate: new Date(),
             createdById: cathedralUserId // The Cathedral user is the creator of their own link
-        }, this._permissionInteractor)
+        })
 
         return {
             response_type: 'ephemeral',

--- a/application/slack/SlackUserInteractor.ts
+++ b/application/slack/SlackUserInteractor.ts
@@ -68,7 +68,6 @@ export class SlackUserInteractor extends Interactor<SlackUserMetaType> {
      * @throws {PermissionDeniedException} If the current user is not a system admin
      */
     async unlinkUser(props: { slackUserId: string, teamId: string }): Promise<void> {
-
         // Only system admins can perform admin-level user unlinking operations
         if (!this._permissionInteractor.isSystemAdmin()) {
             throw new PermissionDeniedException('Only system administrators can unlink users through admin operations')

--- a/application/slack/SlackUserInteractor.ts
+++ b/application/slack/SlackUserInteractor.ts
@@ -35,21 +35,29 @@ export class SlackUserInteractor extends Interactor<SlackUserMetaType> {
     }
 
     /**
-     * Link a Slack user to a Cathedral user (admin/bot operation)
+     * Link a Slack user to a Cathedral user
      *
      * @param props - User linking parameters
+     * @param userPermissionInteractor - Optional PermissionInteractor for the requesting user (defaults to internal one)
      * @throws {NotFoundException} If the Cathedral user does not exist
      * @throws {DuplicateEntityException} If the link already exists
-     * @throws {PermissionDeniedException} If the current user is not a system admin or the Slack bot
+     * @throws {PermissionDeniedException} If the current user is not the user being linked or a system admin
      */
-    async linkUser(props: SlackUserMetaType): Promise<void> {
-        await this._permissionInteractor.assertSlackBot()
+    async linkUser(props: SlackUserMetaType, userPermissionInteractor?: PermissionInteractor): Promise<void> {
+        const permissionChecker = userPermissionInteractor || this._permissionInteractor
+        const currentUserId = permissionChecker.userId
+
+        if (props.cathedralUserId !== currentUserId && !permissionChecker.isSystemAdmin()) {
+            throw new PermissionDeniedException(
+                `User with id ${currentUserId} does not have permission to link Slack user to Cathedral user ${props.cathedralUserId}`
+            )
+        }
 
         await this.repository.linkSlackUser({
             slackUserId: props.slackUserId,
             cathedralUserId: props.cathedralUserId,
             teamId: props.teamId,
-            createdById: this._permissionInteractor.userId,
+            createdById: currentUserId,
             creationDate: new Date()
         })
     }
@@ -59,10 +67,15 @@ export class SlackUserInteractor extends Interactor<SlackUserMetaType> {
      *
      * @param props - User unlinking parameters
      * @throws {NotFoundException} If the link does not exist
-     * @throws {PermissionDeniedException} If the current user is not a system admin or the Slack bot
+     * @throws {PermissionDeniedException} If the current user is not a system admin
      */
     async unlinkUser(props: { slackUserId: string, teamId: string }): Promise<void> {
-        await this._permissionInteractor.assertSlackBot()
+
+        // Only system admins can perform admin-level user unlinking operations
+        if (!this._permissionInteractor.isSystemAdmin()) {
+            throw new PermissionDeniedException('Only system administrators can unlink users through admin operations')
+        }
+
         await this.repository.unlinkSlackUser(props)
     }
 
@@ -70,34 +83,15 @@ export class SlackUserInteractor extends Interactor<SlackUserMetaType> {
      * Check if a Slack user is linked to a Cathedral user for a given team
      *
      * @param props - User checking parameters
-     * @throws {PermissionDeniedException} If the current user is not a system admin or the Slack bot
      * @returns True if the user is linked, false otherwise
+     * @throws {PermissionDeniedException} If the current user is not a system admin
      */
     async isSlackUserLinked(props: { slackUserId: string, teamId: string }): Promise<boolean> {
-        await this._permissionInteractor.assertSlackBot()
-
-        return this.repository.isSlackUserLinked(props)
-    }
-
-    /**
-     * Link a Slack user to a Cathedral user (user-level permissions)
-     *
-     * @param props - User linking parameters
-     * @param userPermissionInteractor - PermissionInteractor for the requesting user
-     * @throws {NotFoundException} If the Cathedral user does not exist
-     * @throws {DuplicateEntityException} If the link already exists
-     * @throws {PermissionDeniedException} If the current user is not the user being linked or a system admin
-     */
-    async linkSlackUserAsUser(props: SlackUserMetaType, userPermissionInteractor: PermissionInteractor): Promise<void> {
-        const currentUserId = userPermissionInteractor.userId
-
-        if (props.cathedralUserId !== currentUserId && !userPermissionInteractor.isSystemAdmin()) {
-            throw new PermissionDeniedException(
-                `User with id ${currentUserId} does not have permission to link Slack user to Cathedral user ${props.cathedralUserId}`
-            )
+        if (!this._permissionInteractor.isSystemAdmin()) {
+            throw new PermissionDeniedException('Only system administrators can check user linking status')
         }
 
-        await this.repository.linkSlackUser(props)
+        return this.repository.isSlackUserLinked(props)
     }
 
     /**

--- a/application/slack/SlackUserInteractor.ts
+++ b/application/slack/SlackUserInteractor.ts
@@ -38,16 +38,14 @@ export class SlackUserInteractor extends Interactor<SlackUserMetaType> {
      * Link a Slack user to a Cathedral user
      *
      * @param props - User linking parameters
-     * @param userPermissionInteractor - Optional PermissionInteractor for the requesting user (defaults to internal one)
      * @throws {NotFoundException} If the Cathedral user does not exist
      * @throws {DuplicateEntityException} If the link already exists
      * @throws {PermissionDeniedException} If the current user is not the user being linked or a system admin
      */
-    async linkUser(props: SlackUserMetaType, userPermissionInteractor?: PermissionInteractor): Promise<void> {
-        const permissionChecker = userPermissionInteractor || this._permissionInteractor
-        const currentUserId = permissionChecker.userId
+    async linkUser(props: SlackUserMetaType): Promise<void> {
+        const currentUserId = this._permissionInteractor.userId
 
-        if (props.cathedralUserId !== currentUserId && !permissionChecker.isSystemAdmin()) {
+        if (props.cathedralUserId !== currentUserId && !this._permissionInteractor.isSystemAdmin()) {
             throw new PermissionDeniedException(
                 `User with id ${currentUserId} does not have permission to link Slack user to Cathedral user ${props.cathedralUserId}`
             )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@final-hill/cathedral",
-    "version": "0.29.4",
+    "version": "0.29.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@final-hill/cathedral",
-            "version": "0.29.4",
+            "version": "0.29.5",
             "hasInstallScript": true,
             "license": "AGPL-3.0-only",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@final-hill/cathedral",
-    "version": "0.29.4",
+    "version": "0.29.5",
     "description": "Requirements management system",
     "keywords": [],
     "private": true,

--- a/server/api/slack/link-user.post.ts
+++ b/server/api/slack/link-user.post.ts
@@ -44,7 +44,7 @@ export default defineEventHandler(async (event) => {
     if (payload.slackUserId !== slackUserId)
         handleDomainException('Token mismatch')
 
-    await slackUserInteractor.linkSlackUserAsUser({
+    await slackUserInteractor.linkUser({
         slackUserId,
         teamId,
         cathedralUserId: session.user.id,

--- a/server/api/slack/link-user.post.ts
+++ b/server/api/slack/link-user.post.ts
@@ -50,7 +50,7 @@ export default defineEventHandler(async (event) => {
         cathedralUserId: session.user.id,
         createdById: session.user.id,
         creationDate: new Date()
-    }, userPermissionInteractor).catch(handleDomainException)
+    }).catch(handleDomainException)
 
     return { message: 'Slack user linked successfully.' }
 })


### PR DESCRIPTION
Refactor Slack user linking logic to simplify permission checks and remove redundant methods